### PR TITLE
Add react-native-worklets dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,8 @@
         "react-native-svg": "15.12.1",
         "react-native-url-polyfill": "^2.0.0",
         "react-native-web": "^0.21.0",
-        "react-native-webview": "13.15.0"
+        "react-native-webview": "13.15.0",
+        "react-native-worklets": "^0.6.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -1350,7 +1351,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
       "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -8607,7 +8607,6 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.6.0.tgz",
       "integrity": "sha512-yETMNuCcivdYWteuG4eRqgiAk2DzRCrVAaEBIEWPo4emrf3BNjadFo85L5QvyEusrX9QKE3ZEAx8U5A/nbyFgg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -8632,7 +8631,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-native-gesture-handler": "~2.28.0",
     "react-native-get-random-values": "^1.11.0",
     "react-native-reanimated": "~4.1.1",
+    "react-native-worklets": "^0.6.0",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",


### PR DESCRIPTION
## Summary
- add the react-native-worklets dependency alongside react-native-reanimated
- regenerate the npm lockfile to include the new package

## Testing
- npm install
- npx expo start --clear

------
https://chatgpt.com/codex/tasks/task_e_68e26254f084832f82cbfba76f1e52ba